### PR TITLE
content script 중복 실행 문제 완벽 해결

### DIFF
--- a/src/pages/content/root.tsx
+++ b/src/pages/content/root.tsx
@@ -1,5 +1,5 @@
 /* ------------------------------------------------------------------ */
-/* 여기 배열에 “실행할 스크립트”를 추가만 하면 자동으로 등록된다.        */
+/* 실행할 스크립트를 배열에 추가만 하면 자동으로 등록된다                */
 /* ------------------------------------------------------------------ */
 import runPRTitleAutoInsert from './prTitleAutoInsert';
 import runSampleNaverScript from './sampleNaver';
@@ -7,94 +7,67 @@ import runSampleNaverScript from './sampleNaver';
 const REGISTERED_SCRIPTS: Array<() => void> = [runSampleNaverScript, runPRTitleAutoInsert];
 
 /* ------------------------------------------------------------------ */
-/* GitHub SPA 네비게이션 대응을 위한 유틸, 센티널 설정                   */
+/* IIFE로 감싸 조건부 return 오류 방지                                 */
 /* ------------------------------------------------------------------ */
+(() => {
+  /* 1. 서브프레임에 주입된 경우 즉시 종료 (중복 실행 차단) */
+  if (window.self !== window.top) {
+    console.debug('[ContentScript] sub-frame → 실행 차단');
 
-/* GitHub가 실제 콘텐츠를 교체하는 turbo-frame / pjax 컨테이너 */
-const FRAME_SELECTOR = 'turbo-frame#repo-content-turbo-frame, div#repo-content-pjax-container';
-
-/* turbo-frame 내부에 삽입할 센티널(meta) ID */
-const SENTINEL_ID = '__pr-review-sentinel';
-
-/* 마지막으로 스크립트를 실행한 URL (중복 실행 차단) */
-let lastRunUrl = '';
-
-/* 실행 여부 flag (현재 트리거에서 한 번만 실행되게) */
-let didRun = false;
-
-/* 현재 turbo-frame를 반환하는 함수 */
-const getFrame = (): HTMLElement | null => document.querySelector<HTMLElement>(FRAME_SELECTOR);
-
-/* turbo-frame 내부에 센티널 존재 여부를 반환하는 함수 */
-const hasSentinel = (): boolean => !!getFrame()?.querySelector(`#${SENTINEL_ID}`);
-
-/* turbo-frame 내부에 센티널(meta) 삽입하는 함수 */
-const addSentinel = () => {
-  const frame = getFrame();
-  if (!frame || hasSentinel()) {
     return;
   }
 
-  const meta = document.createElement('meta');
-  meta.id = SENTINEL_ID;
-  frame.appendChild(meta);
-};
+  /* 2. 센티널(meta)로 “한 페이지 1 회” 실행 보장 */
+  const SENTINEL_ID = '__pr-review-sentinel';
+  if (document.getElementById(SENTINEL_ID)) {
+    console.debug('[ContentScript] sentinel 존재 → 중복 실행 차단');
 
-/**
- * 등록된 모든 Content Script를 실행한다.
- * - URL이 같고 센티널이 남아 있으면 중복 실행하지 않음
- * - 한 트리거에서 한 번만 실행(flag) : 중복 실행 방지
- */
-const runContentScripts = () => {
-  if (didRun) {
     return;
   }
-  didRun = true;
-
-  /* 같은 URL + 센티널 존재 → 이미 실행됨 : 중복 실행 차단 */
-  if (location.href === lastRunUrl && hasSentinel()) {
-    return;
+  {
+    const meta = document.createElement('meta');
+    meta.id = SENTINEL_ID;
+    document.head.appendChild(meta);
   }
 
-  lastRunUrl = location.href;
+  /* 3. GitHub가 실제 콘텐츠를 교체하는 turbo-frame / pjax 컨테이너 */
+  const FRAME_SELECTOR = 'turbo-frame#repo-content-turbo-frame, div#repo-content-pjax-container';
+  const getFrame = (): HTMLElement | null => document.querySelector<HTMLElement>(FRAME_SELECTOR);
 
-  /* 등록된 스크립트 일괄 실행 */
-  REGISTERED_SCRIPTS.forEach(fn => {
-    try {
-      fn();
-    } catch (err) {
-      console.error('[ContentScript] 실행 실패:', err);
+  /* 4. 마지막으로 스크립트를 실행한 URL (turbo 전환 중복 방지) */
+  let lastRunUrl = '';
+
+  /* 5. 등록된 스크립트 실행 함수 */
+  const runContentScripts = () => {
+    /* 같은 URL이면 재실행 X */
+    if (location.href === lastRunUrl) {
+      return;
+    }
+    lastRunUrl = location.href;
+
+    REGISTERED_SCRIPTS.forEach(fn => {
+      try {
+        fn();
+      } catch (err) {
+        console.error('[ContentScript] 실행 실패:', err);
+      }
+    });
+  };
+
+  /* 6. 최초 1회 실행 */
+  runContentScripts();
+
+  /* 7. GitHub Hotwire 이벤트(turbo:load) */
+  window.addEventListener('turbo:load', runContentScripts);
+
+  /* 8. 앞으로/뒤로(popstate) */
+  window.addEventListener('popstate', runContentScripts);
+
+  /* 9. turbo-frame 교체 감지 → frame 새로 생기면 재실행 */
+  const bodyObserver = new MutationObserver(() => {
+    if (getFrame() && location.href !== lastRunUrl) {
+      runContentScripts();
     }
   });
-
-  /* 실행 후 센티널 삽입 */
-  addSentinel();
-};
-
-/* ------------------------------------------------------------------ */
-/* 실행 트리거 등록                                                   */
-/* ------------------------------------------------------------------ */
-
-/* 최초 페이지 로드 */
-runContentScripts();
-
-/* turbo-frame 교체, 센티널이 사라지면 flag를 false로 초기화 + 재실행 */
-const bodyObserver = new MutationObserver(() => {
-  if (!hasSentinel()) {
-    didRun = false; /* frame이 교체된 경우, flag 초기화 */
-    runContentScripts(); /* 최초 한 번만 실행됨 */
-  }
-});
-bodyObserver.observe(document.body, { childList: true, subtree: true });
-
-/* GitHub Hotwire 이벤트(turbo:load) → flag 초기화 + 실행 */
-window.addEventListener('turbo:load', () => {
-  didRun = false;
-  runContentScripts();
-});
-
-/* 앞으로 / 뒤로(popstate) → flag 초기화 + 실행 */
-window.addEventListener('popstate', () => {
-  didRun = false;
-  runContentScripts();
-});
+  bodyObserver.observe(document.body, { childList: true, subtree: true });
+})(); /* IIFE 끝 */


### PR DESCRIPTION
## 주요 이슈 (PR 목적)

* 기존 코드에서는 GitHub의 turbo-frame 또는 PJAX 기반 SPA 네비게이션 상황에서 content script가 동일 페이지에서 여러 번 실행되는 현상이 발생했습니다.
* 서브프레임(iframe, turbo-frame 등)에 content script가 중복 주입되어, 스크립트가 의도치 않게 여러 번 실행되는 문제가 있었습니다.
* 이로 인해 리뷰 상태 등 동적으로 삽입되는 컴포넌트가 중복 렌더링되거나, MutationObserver를 통한 무한 루프가 발생할 수 있었습니다.

---

## 개선 사항

1. **중복 실행 방지**

   * top-level frame이 아닌 경우(content script가 서브프레임에 주입될 경우) 즉시 실행을 중단하여, 불필요한 중복 실행을 차단합니다.
   * 센티널(meta 태그) 삽입 방식을 통해 한 페이지 내에서 content script가 정확히 한 번만 실행되도록 보장합니다.

2. **SPA 전환 대응**

   * turbo-frame, PJAX 등으로 GitHub 내부에서 SPA 전환이 발생할 때마다 URL 및 DOM의 변화를 감지하여 스크립트를 재실행하도록 MutationObserver 및 이벤트 리스너(turbo\:load, popstate)를 추가하였습니다.
   * 이미 실행한 URL에서는 재실행하지 않도록 마지막 실행 URL을 체크하여 불필요한 중복 호출을 방지합니다.

3. **스크립트 자동 등록 구조**

   * 실행할 스크립트들을 배열에 등록하여, 코드 변경 시 일관성을 유지하고 유지보수를 용이하게 하였습니다.